### PR TITLE
Add optional callback to onYes() in Modal.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ A replacement for the alert box
   });
 ```
 
+## TO TEST:
+run `npm test`
+
 
 ##TODO
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,4 @@
 var istanbul = require('browserify-istanbul');
-var hbsfy = require('hbsfy');
 var coverOptions = {
   ignore: [ '**/**.handlebars'],
   defaultIgnore: true
@@ -39,7 +38,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'tests/**': ['sourcemap','browserify'],
+      'tests/**': ['browserify'],
       'src/**/**.js': ['sourcemap','browserify','coverage']
 
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maxwell-modal",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -71,14 +71,28 @@ module.exports = Backbone.View.extend({
     'click .no-button' : 'noButton'
   },
   yesButton: function() {
-    var success = true;
+    var self = this;
 
-    if (this.onYes) {
-      success = this.onYes();
+    // If onYes is not a function, then close modal if truthy
+    if (!_.isFunction(this.onYes)) {
+      if (this.onYes === true) {
+        self.$el.find('.modal').modal('hide');
+      }
+      return;
     }
-
-    if (success) {
-      this.$el.find('.modal').modal('hide');
+    // If onYes is a function, then call it and close modal if truthy
+    if (this.onYes.length === 1) {
+      // If onYes has been defined with an arity of 1, then feed it a callback
+      this.onYes(function (closeModal) {
+        if (closeModal === true) {
+          self.$el.find('.modal').modal('hide');
+        }
+      });
+    } else if (this.onYes.length === 0) {
+      // If onYes has been defined with an arity of 0, then call it
+      if (this.onYes() === true) {
+        self.$el.find('.modal').modal('hide');
+      }
     }
   },
 

--- a/tests/modal.js
+++ b/tests/modal.js
@@ -17,8 +17,13 @@ describe('Modal', function () {
       title: testTitle,
 
       footer: testFooter,
-      onShow: function() {show = true;},
-      onHide: function() {hide = true;expect(hide).toBe(true);}
+      onShow: function() {
+        show = true;
+      },
+      onHide: function() {
+        hide = true;
+        expect(hide).toBe(true);
+      }
     });
     var contentView = new ContentModal();
     var body = contentView.render().el;
@@ -26,22 +31,25 @@ describe('Modal', function () {
     expect($(body).find('h3').text()).toBe(testTitle);
     expect($(body).find('.modal-body').text()).toBe(testBody);
     expect($(body).find('.modal-footer').text()).toBe(testFooter);
-
   });
-  it('should not be dismissable but hides', function(done) {
+
+  it('should not be dismissable but hides', function() {
     var show = false;
-    var hide = false;
     var testTitle = 'Test Title';
     var testBody = 'Test Body';
     var testFooter = 'Test Footer';
-
+    var onHide = function () {
+      onHide.called = true;
+    };
     var ContentModal = Modal.extend({
       body: testBody,
       title: testTitle,
       dismissable: false,
       footer: testFooter,
-      onShow: function() {show = true;},
-      onHide: function() {hide = true;expect(hide).toBe(true); done();}
+      onShow: function() {
+        show = true;
+      },
+      onHide: onHide
     });
     var contentView = new ContentModal();
     var body = contentView.render().el;
@@ -50,14 +58,13 @@ describe('Modal', function () {
     expect($(body).find('.modal-body').text()).toBe(testBody);
     expect($(body).find('.modal-footer').text()).toBe(testFooter);
     $(body).find('.modal').modal('hide');
+    expect(onHide.called).toBe(true);
   });
-  it('should functions without callbacks', function() {
-    var show = false;
-    var hide = false;
+
+  it('should function without callbacks', function() {
     var testTitle = 'Test Title';
     var testBody = 'Test Body';
     var testFooter = 'Test Footer';
-
     var ContentModal = Modal.extend({
       body: testBody,
       title: testTitle,
@@ -70,14 +77,73 @@ describe('Modal', function () {
     expect($(body).find('h3').text()).toBe(testTitle);
     expect($(body).find('.modal-body').text()).toBe(testBody);
     expect($(body).find('.modal-footer').text()).toBe(testFooter);
+
+    // This line is here to increase code coverage because there is an
+    // onHide hook attached to the modal('hide') event that checks whether
+    // the onHide function should be fired
     $(body).find('.modal').modal('hide');
   });
+
+  var modalCloseTests = [
+    {
+      closes: true,
+      condition: 'onYes is true',
+      onYes: true
+    }, {
+      closes: false,
+      condition: 'onYes is not set',
+      onYes: null
+    }, {
+      closes: true,
+      condition: 'onYes returns a callback with true for its parameter',
+      onYes: function (callback) {
+        return callback(true);
+      }
+    }, {
+      closes: false,
+      condition: 'onYes returns a callback with false for its parameter',
+      onYes: function (callback) {
+        return callback(false);
+      }
+    }, {
+      closes: true,
+      condition: 'onYes is a function that returns true',
+      onYes: function () {
+        return true;
+      }
+    }, {
+      closes: false,
+      condition: 'onYes is a function that returns false',
+      onYes: function () {
+        return false;
+      }
+    }, {
+      closes: false,
+      condition: 'onYes has more than one parameter',
+      onYes: function (one, two) {
+        return one + two;
+      }
+    }
+  ];
+  modalCloseTests.forEach(function (test) {
+    var closes = test.closes ? '' : 'NOT';
+    var vis = test.closes ? 'none' : 'block';
+    it('should' + closes + ' ' + test.condition, function () {
+      var ContentModal = Modal.extend({
+        dismissable: false,
+        onYes: test.onYes
+      });
+      var contentView = new ContentModal();
+      var body = contentView.render().el;
+      expect($(body).find('.modal').css('display')).toBe('block');
+      contentView.yesButton();
+      expect($(body).find('.modal').css('display')).toBe(vis);
+    });
+  });
+
   it('should have footer as function', function() {
-    var show = false;
-    var hide = false;
     var testTitle = 'Test Title';
     var testBody = 'Test Body';
-    var testFooter = 'Test Footer';
 
     var ContentModal = Modal.extend({
       body: testBody,
@@ -93,8 +159,8 @@ describe('Modal', function () {
     expect($(body).find('h3').text()).toBe(testTitle);
     expect($(body).find('.modal-body').text()).toBe(testBody);
     expect($(body).find('.modal-footer').text()).toBe('foo');
-    $(body).find('.modal').modal('hide');
   });
+
   it('should have content only', function() {
     var testBody = 'Test Body';
 
@@ -106,15 +172,15 @@ describe('Modal', function () {
     var body = contentView.render().el;
     expect($(body).find('.modal-content').text()).toBe(testBody);
   });
-  it('should have rando header', function() {
-    var testBody = 'Test Body';
 
+  it('should have a header', function() {
+    var testHeader = 'Test Header';
     var ContentModal = Modal.extend({
-      header: testBody
+      header: testHeader
 
     });
     var contentView = new ContentModal();
     var body = contentView.render().el;
-    expect($(body).find('.modal-header').text()).toBe(testBody);
+    expect($(body).find('.modal-header').text()).toBe(testHeader);
   });
 });


### PR DESCRIPTION
I attempted a Promise strategy, but it complicated the interface for the
user. Now, Modal.js intelligently determines if the onYes defined by the
user has an arity of 1 or 0. If its arity is 1, then it assumes it's a
callback and closes the modal depending on whether the callback returns
a Boolean value of true.

@securingsincity - code review please :)
