### PR TITLE
iframe-modal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.Modal = require('./src/Modal');
 exports.ConfirmModal = require('./src/ConfirmModal');
 exports.AlertModal = require('./src/AlertModal');
+exports.iframeModal = require('./src/iframeModal');

--- a/src/iframeModal.js
+++ b/src/iframeModal.js
@@ -1,0 +1,15 @@
+var Backbone = require('backbone');
+var $ = require('jquery');
+headerTemplate = require('./templates/iframe-header.handlebars');
+Backbone.$ = $;
+var Modal = require('./Modal');
+
+module.exports = Modal.extend({
+	dismissable: false,
+	header: function(){
+		return headerTemplate();
+	},
+	footer: function(){
+		return null;
+	}
+});

--- a/src/templates/iframe-header.handlebars
+++ b/src/templates/iframe-header.handlebars
@@ -1,0 +1,3 @@
+<div class="modal-header">
+	  <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+</div>

--- a/tests/iframeModal.js
+++ b/tests/iframeModal.js
@@ -1,0 +1,31 @@
+var Modal = require('../src/iframeModal.js');
+var $ = require('jquery');
+global.jQuery = $;
+global.$ = $;
+require('../bower_components/bootstrap/dist/js/bootstrap.min.js');
+
+describe('iframe Modal', function () {
+		var show = false;
+		var hide = false;
+		var testTitle = 'Test Title';
+		var testBody = 'Test Body';
+
+		var ContentModal = Modal.extend({
+			body: testBody,
+			title: testTitle,
+			onShow: function(){show = true},
+			onHide: function(){hide = true; expect(hide).toBe(true);}
+		});
+		var contentView = new ContentModal();
+		var body = contentView.render().el;
+	it('Should render the iframe with a close button in the header', function (){
+		expect($(body).find('.modal-header button').text()).toBe('×');
+	});
+	it('Should render the iframe without a footer', function () {
+		expect($(body).find('.modal-footer').html()).toBe(undefined);
+	});
+	it('Should have the dissmissable options set to false', function () {
+		expect($(body).find('.modal').data('bs.modal').options.backdrop).toBe('static');
+		expect($(body).find('.modal').data('bs.modal').options.keyboard).toBe(false);
+	});
+});


### PR DESCRIPTION
Use-case: Employees can have the option of closing the modal by selecting the 'X' close button, but a misclick will not cause the modal to close on them. 
